### PR TITLE
:closed_lock_with_key: Demo site works over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin that adds the ability to search (geocode) a leaflet powered map.
 
 ## Requirements
 
-Works well with ```leaflet-0.7.3```, ```leaflet-0.8-dev```. 
+Works well with ```leaflet-0.7.3```, ```leaflet-0.8-dev```.
 
 Should work with the latest version of leaflet as well. If not, please log an issue
 
@@ -17,10 +17,10 @@ Should work with the latest version of leaflet as well. If not, please log an is
 **Step 1**: Import the required leaflet javascript and css files
 
 ```html
-<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
-<link rel="stylesheet" href="http://rawgit.com/pelias/leaflet-geocoder/master/pelias-leaflet-geocoder.css" />
-<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet-src.js"></script>
-<script src="http://rawgit.com/pelias/leaflet-geocoder/master/pelias-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+<link rel="stylesheet" href="//rawgit.com/pelias/leaflet-geocoder/master/pelias-leaflet-geocoder.css" />
+<script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
+<script src="//rawgit.com/pelias/leaflet-geocoder/master/pelias-leaflet-geocoder.js"></script>
 
 ```
 
@@ -48,7 +48,7 @@ L.control.geocoder({
 
 // Taking just the center of the map (lat/lon) into account
 L.control.geocoder({
-  latlon:true, 
+  latlon:true,
   placeholder: 'Search nearby (from the center/latlon)'
 }).addTo(map);
 
@@ -58,37 +58,37 @@ var southWest = L.latLng(40.712, -74.227),
     bounds = L.latLngBounds(southWest, northEast);
 
 L.control.geocoder({
-  bbox:bounds, 
+  bbox:bounds,
   placeholder: 'Search within ' + bounds.toBBoxString() //given bbox
 }).addTo(map);
 
 // Taking just the bounding box of the map view into account
 L.control.geocoder({
-  bbox:true, 
+  bbox:true,
   placeholder: 'Search within the bounds' //map\'s view/bbox
 }).addTo(map);
 
 // Coarse Geocoder: search only admin layers
 L.control.geocoder({
-  layers: 'admin', 
+  layers: 'admin',
   placeholder: 'Coarse Geocoder'
 }).addTo(map);
 
 // Address Geocoder: search only (street) address layers
 L.control.geocoder({
-  layers: 'address', 
+  layers: 'address',
   placeholder: 'Address Geocoder'
 }).addTo(map);
 
 // POI Geocoder: search only points of interests
 L.control.geocoder({
-  layers: 'poi', 
+  layers: 'poi',
   placeholder: 'POI Geocoder'
 }).addTo(map);
 
 // Street level Geocoder: search only poi and street addresses
 L.control.geocoder({
-  layers: 'poi,address', 
+  layers: 'poi,address',
   placeholder: 'Street Geocoder'
 }).addTo(map);
 
@@ -105,9 +105,9 @@ L.control.geocoder({
   pan_to_point: true
 }).addTo(map);
 
-// Setting full width on the search text box 
+// Setting full width on the search text box
 // by default: true - on mobile/ any viewport of 650px and less
-// if viewport wider than 650px, its set to false 
+// if viewport wider than 650px, its set to false
 // and width is defined in the CSS (250px)
 // as per https://github.com/pelias/leaflet-geocoder/issues/7
 L.control.geocoder({
@@ -116,7 +116,7 @@ L.control.geocoder({
 
 // hide_other_controls
 // Configure if you want to hide other leaflet controls while performing search
-// by default hide_other_controls is set to false 
+// by default hide_other_controls is set to false
 // as per https://github.com/pelias/leaflet-geocoder/issues/7
 L.control.geocoder({
     hide_other_controls: true
@@ -139,5 +139,4 @@ L.control.geocoder({
 
 ```
 
-**Step 4**: Rejoice! 
-
+**Step 4**: Rejoice!

--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Pelias Demo</title>
+    <title>Pelias Geocoder Leaflet Plugin</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
     <!-- Load Leaflet from their CDN -->
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
     <link rel="stylesheet" href="pelias-leaflet-geocoder.css" />
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet-src.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
     <style>
       #map {
         position: fixed;
@@ -20,7 +20,7 @@
       }
     </style>
     <script src="pelias-leaflet-geocoder.js"></script>
-    
+
   </head>
   <body>
       <div id="map"></div>
@@ -28,8 +28,8 @@
       <script type="text/javascript">
         var map = L.map('map').setView([40.7259, -73.9805], 12);
 
-        L.tileLayer('http://{s}.tiles.mapbox.com/v3/randyme.i0568680/{z}/{x}/{y}.png', {
-            attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+        L.tileLayer('//{s}.tiles.mapbox.com/v3/randyme.i0568680/{z}/{x}/{y}.png', {
+            attribution: 'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
             maxZoom: 18,
             minZoom: 3,
             noWrap: true
@@ -46,7 +46,7 @@
 
         // Taking just the center of the map (lat/lon) into account
         // L.control.geocoder({
-        //   latlon:true, 
+        //   latlon:true,
         //   placeholder: 'Search nearby (from the center/latlon)'
         // }).addTo(map);
 
@@ -56,38 +56,38 @@
         //     bounds = L.latLngBounds(southWest, northEast);
 
         // L.control.geocoder({
-        //   bbox:bounds, 
+        //   bbox:bounds,
         //   placeholder: 'Search within ' + bounds.toBBoxString() //map\'s view/bbox
         // }).addTo(map);
 
         // Taking just the bounding box of the map view into account
         // L.control.geocoder({
-        //   bbox:true, 
+        //   bbox:true,
         //   placeholder: 'Search within the bounds' //map\'s view/bbox
         // }).addTo(map);
 
         // Query just the admin layers
         // L.control.geocoder({
-        //   layers: 'admin', 
+        //   layers: 'admin',
         //   placeholder: 'Coarse Geocoder'
         // }).addTo(map);
-        
+
         // Customizing icons
         // L.control.geocoder({
         //     point_icon: 'http://www.somewhereontheweb.com/download/img/point.png',
         //     polygon_icon: 'https://cloud.com/polygon_icon.svg'
         // }).addTo(map);
-        
-        // Configure if you want to zoom/pan to a point while browsing the results 
+
+        // Configure if you want to zoom/pan to a point while browsing the results
         // (up/down arrows)
         // pan_to_point set to true (by default)
         // L.control.geocoder({
         //     pan_to_point: true
         // }).addTo(map);
 
-        // Setting full width on the search text box 
+        // Setting full width on the search text box
         // by default: true - on mobile/ any viewport of 650px and less
-        // if viewport wider than 650px, its set to false 
+        // if viewport wider than 650px, its set to false
         // and width is defined in the CSS (250px)
         // as per https://github.com/pelias/leaflet-geocoder/issues/7
         // L.control.geocoder({
@@ -96,7 +96,7 @@
 
         // hide_other_controls
         // Configure if you want to hide other leaflet controls while performing search
-        // by default hide_other_controls is set to false 
+        // by default hide_other_controls is set to false
         // as per https://github.com/pelias/leaflet-geocoder/issues/7
         // L.control.geocoder({
         //     hide_other_controls: true
@@ -118,7 +118,7 @@
         // L.control.geocoder({
         //     expanded: false
         // }).addTo(map);
-        
+
         // L.control.geocoder({
         //     expanded: false,
         //     drop_pin: false,

--- a/pelias-leaflet-geocoder.js
+++ b/pelias-leaflet-geocoder.js
@@ -6,14 +6,14 @@
 L.Control.Geocoder = L.Control.extend({
   options: {
     position: 'topleft',
-    attribution: 'Geocoding by <a href=\'http://mapzen.com/pelias\'>Pelias</a>',
+    attribution: 'Geocoding by <a href=\'https://mapzen.com/pelias\'>Pelias</a>',
     url: '//pelias.mapzen.com',
     placeholder: 'Search',
     title: 'Search',
     bbox: false,
     latlon: null,
     layers: 'poi,admin,address',
-    pan_to_point: true, 
+    pan_to_point: true,
     point_icon: 'img/point_icon.png',
     polygon_icon: 'img/polygon_icon.png',
     full_width: window.innerWidth < 650,
@@ -43,14 +43,14 @@ L.Control.Geocoder = L.Control.extend({
 
   getBoundingBoxParam: function (params) {
     var bbox= this.options.bbox;
-    
+
     if ( !bbox ) {
       return params;
     }
-    
+
     if ( (typeof bbox !== 'object') || !bbox.isValid() ) {
       bbox = this._map.getBounds();
-    } 
+    }
 
     var bbox_center  = bbox.getCenter();
     params.bbox = bbox.toBBoxString();
@@ -70,11 +70,11 @@ L.Control.Geocoder = L.Control.extend({
      * false //Boolean - No latlon to be considered
     */
     var latlon= this.options.latlon;
-    
+
     if ( !latlon ) {
       return params;
     }
-    
+
     if (latlon.constructor === Array) {
       // TODO Check for array size, throw errors if invalid lat/lon
       params.lat = latlon[0];
@@ -103,9 +103,9 @@ L.Control.Geocoder = L.Control.extend({
   suggest: function(input) {
     var url = this.options.url + '/suggest';
     var params = {
-      input: input    
+      input: input
     };
-    
+
     this.callPelias(url, params);
   },
 
@@ -113,7 +113,7 @@ L.Control.Geocoder = L.Control.extend({
     params = this.getBoundingBoxParam( params );
     params = this.getLatLonParam( params );
     params = this.getLayers( params );
-    
+
     // Since we always use properties.text we dont need the details
     // See https://github.com/pelias/api/releases/tag/1.2.0
     params.details = false;
@@ -127,7 +127,7 @@ L.Control.Geocoder = L.Control.extend({
       }
     }, this);
   },
-  
+
   highlight: function( text, focus ){
     var r = RegExp( '('+ focus + ')', 'gi' );
     return text.replace( r, '<strong>$1</strong>' );
@@ -139,16 +139,16 @@ L.Control.Geocoder = L.Control.extend({
 
     if( type.match('geoname') ){
       return { icon: point_icon, title: 'source: geonames'};
-    } else if( type.match('osm') || 
-               type.match('osmway')  || 
-               type.match('osmnode') || 
+    } else if( type.match('osm') ||
+               type.match('osmway')  ||
+               type.match('osmnode') ||
                type.match('osmaddress')){
       return { icon: point_icon, title: 'source: openstreetmap'};
-    } else if( type.match('admin0') || 
-               type.match('admin1') || 
-               type.match('admin2') || 
+    } else if( type.match('admin0') ||
+               type.match('admin1') ||
+               type.match('admin2') ||
                type.match('locality') ||
-               type.match('neighborhood') || 
+               type.match('neighborhood') ||
                type.match('local_admin') ){
       return { icon: polygon_icon, title: 'source: quattroshapes'};
     } else if( type.match('openaddresses') ){
@@ -159,13 +159,13 @@ L.Control.Geocoder = L.Control.extend({
 
   showResults: function(features) {
     var list;
-    var self = this; 
+    var self = this;
     var results_container = this._results;
     results_container.innerHTML = '';
     results_container.style.display = 'block';
     // manage result box height
     results_container.style.maxHeight = (this._map.getSize().y - results_container.offsetTop - this._container.offsetTop - 10) + 'px';
-    
+
     features.forEach( function( feature ){
       if(!list) {
         list = L.DomUtil.create('ul', 'pelias-list', results_container);
@@ -175,12 +175,12 @@ L.Control.Geocoder = L.Control.extend({
       var result_meta = self.getMeta(feature.properties.layer);
 
       result_item.layer  = feature.properties.layer;
-      result_item.coords = feature.geometry.coordinates; 
+      result_item.coords = feature.geometry.coordinates;
 
       var layer_icon_con = L.DomUtil.create('span', 'layer_icon_container', result_item);
       var layer_icon     = L.DomUtil.create('img', 'layer_icon', layer_icon_con);
       layer_icon.src  = result_meta.icon;
-      layer_icon.title= result_meta.title;   
+      layer_icon.title= result_meta.title;
       result_item.innerHTML += self.highlight(feature.properties.text, self._input.value);
     });
   },
@@ -199,7 +199,7 @@ L.Control.Geocoder = L.Control.extend({
 
     var geo = [coords[1], coords[0]];
     this._map.setView( geo, this._map.getZoom() || 8 );
-    
+
     if (this.options.drop_pin) {
       this.marker = new L.marker(geo).bindPopup(text);
       this._map.addLayer(this.marker);
@@ -348,7 +348,7 @@ L.Control.Geocoder = L.Control.extend({
               } else {
                 L.DomUtil.addClass(list[list.length-1], 'pelias-selected');
               }
-              
+
               pan_to_point(this.options.pan_to_point);
 
               L.DomEvent.preventDefault(e);
@@ -372,9 +372,9 @@ L.Control.Geocoder = L.Control.extend({
               L.DomEvent.preventDefault(e);
               break;
             // all other keys
-            default: 
+            default:
               break;
-          } 
+          }
         }, this)
       .on(this._input, 'keyup', this.throttle(function(e){
           var key = e.which || e.keyCode;
@@ -411,10 +411,10 @@ L.Control.Geocoder = L.Control.extend({
             }
             return selected
           };
-          
-          // click event can be registered on the child nodes 
+
+          // click event can be registered on the child nodes
           // that does not have the required coords prop
-          // so its important to find the parent. 
+          // so its important to find the parent.
           findParent();
 
           L.DomUtil.addClass(selected, 'pelias-selected');
@@ -448,9 +448,9 @@ L.control.geocoder = function (options) {
   return new L.Control.Geocoder(options);
 };
 
-/* 
+/*
  * AJAX Utitity function (implements basic HTTP get)
- * TODO check for maximum length for a GET req 
+ * TODO check for maximum length for a GET req
  * TODO alternatively POST if GET cannot be done
  * TODO fallback to JSONP if CORS isnt supported
  */
@@ -534,7 +534,7 @@ var AJAX = {
   request: function(url, params, callback, context) {
     var paramString   = this.serialize(params);
     var httpRequest   = this.http_request(callback, context);
-    
+
     httpRequest.open('GET', url + '?' + paramString);
     httpRequest.send(null);
   }


### PR DESCRIPTION
- Set all third party embeds (JS + CSS) to be protocol-agnostic
- Changed all outbound links to use HTTPS
- Updates documentation to reflect protocol agnosticism

Because cdn.leafletjs.com does not support SSL, this changes the CDN to instead use Cloudflare's [CDNjs](https://cdnjs.com/).

Resolves #13
