### PR TITLE
add meta tags to show full screen when launched from links on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <title>Pelias Geocoder Leaflet Plugin</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
 
     <!-- Load Leaflet from their CDN -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />


### PR DESCRIPTION
add meta tags to show full screen when launched from links on mobile phone home screen, apple/android

this PR allows the demo to launch in full screen when executed from a link on my android home screen, which is nice for demos and to play around with it without seeing the browser navigation bar.

should work on both apple and android devices by loading the page, clicking the 'options' button and then 'save to home screen'. Now when launching the webapp via that link it should be full screen.

source: http://www.html5rocks.com/en/mobile/fullscreen/
