### PR TITLE
Replace protocol relative URLs with HTTPS URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Supports [Leaflet](https://github.com/Leaflet/Leaflet) **v0.7.3** (and higher) a
 
 ```html
 <!-- Load Leaflet from CDN -->
-<link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.css">
-<script src="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
 
 <!-- Load Pelias geocoding plugin after Leaflet -->
 <link rel="stylesheet" href="pelias-leaflet-geocoder.css">

--- a/examples/bounds.html
+++ b/examples/bounds.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
   <!-- Load Leaflet from CDN -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.css">
-  <script src="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
 
   <!-- Load Pelias geocoding plugin after Leaflet -->
   <link rel="stylesheet" href="../dist/pelias-leaflet-geocoder.css">

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
   <!-- Load Leaflet from CDN -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.css">
-  <script src="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
 
   <!-- Load Pelias geocoding plugin after Leaflet -->
   <link rel="stylesheet" href="../dist/pelias-leaflet-geocoder.css">

--- a/examples/leaflet-v1.html
+++ b/examples/leaflet-v1.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
   <!-- Load Leaflet from CDN -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.css">
-  <script src="//cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.1/leaflet.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.1/leaflet.js"></script>
 
   <!-- With leaflet-hash -->
   <script src="https://s3.amazonaws.com/assets-staging.mapzen.com/ui/libraries/leaflet-hash/0.2.1/leaflet-hash.js"></script>

--- a/examples/position.html
+++ b/examples/position.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
   <!-- Load Leaflet from CDN -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.css">
-  <script src="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
 
   <!-- Load Pelias geocoding plugin after Leaflet -->
   <link rel="stylesheet" href="../dist/pelias-leaflet-geocoder.css">

--- a/examples/search-icon-active-state.html
+++ b/examples/search-icon-active-state.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
   <!-- Load Leaflet from CDN -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.css">
-  <script src="//cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
 
   <!-- Load Pelias geocoding plugin after Leaflet -->
   <link rel="stylesheet" href="../dist/pelias-leaflet-geocoder.css">

--- a/examples/tangram.html
+++ b/examples/tangram.html
@@ -7,8 +7,8 @@
   <script src="modernizr.js"></script>
 
   <!-- Load Leaflet from CDN -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.css">
-  <script src="//cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.1/leaflet.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.1/leaflet.js"></script>
 
   <!-- With leaflet-hash -->
   <script src="https://s3.amazonaws.com/assets-staging.mapzen.com/ui/libraries/leaflet-hash/0.2.1/leaflet-hash.js"></script>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <script src="examples/modernizr.js"></script>
 
     <!-- Load Leaflet from CDN -->
-    <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.css">
-    <script src="//cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.1/leaflet.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.1/leaflet.js"></script>
 
     <!-- With leaflet-hash -->
     <script src="https://s3.amazonaws.com/assets-staging.mapzen.com/ui/libraries/leaflet-hash/0.2.1/leaflet-hash.js"></script>


### PR DESCRIPTION
Some links are also changed to use cdnjs, which does support HTTPS,
rather than leafletcdn, which doesn't.
