### PR TITLE
Allow array format for bounds. Add tests.

### DIFF
--- a/dist/pelias-leaflet-geocoder.js
+++ b/dist/pelias-leaflet-geocoder.js
@@ -74,20 +74,42 @@
     },
 
     getBoundingBoxParam: function (params) {
+      /*
+       * this.options.bounds can be one of the following
+       * true //Boolean - take the map bounds
+       * false //Boolean - no bounds
+       * L.latLngBounds(...) //Object
+       * [[10, 10], [40, 60]] //Array
+      */
       var bounds = this.options.bounds;
 
+      // If falsy, bail
       if (!bounds) {
         return params;
       }
 
-      if ((typeof bounds !== 'object') || !bounds.isValid()) {
+      // If set to true, use map bounds
+      // If it is a valid L.LatLngBounds object, get its values
+      // If it is an array, try running it through L.LatLngBounds
+      if (bounds === true) {
         bounds = this._map.getBounds();
+        params = makeParamsFromLeaflet(params, bounds);
+      } else if (typeof bounds === 'object' && bounds.isValid && bounds.isValid()) {
+        params = makeParamsFromLeaflet(params, bounds);
+      } else if (typeof bounds === 'object' && bounds.length > 0) {
+        var latLngBounds = L.latLngBounds(bounds);
+        if (latLngBounds.isValid && latLngBounds.isValid()) {
+          params = makeParamsFromLeaflet(params, latLngBounds);
+        }
       }
 
-      params['boundary.rect.min_lon'] = bounds.getWest();
-      params['boundary.rect.min_lat'] = bounds.getSouth();
-      params['boundary.rect.max_lon'] = bounds.getEast();
-      params['boundary.rect.max_lat'] = bounds.getNorth();
+      function makeParamsFromLeaflet (params, latLngBounds) {
+        params['boundary.rect.min_lon'] = latLngBounds.getWest();
+        params['boundary.rect.min_lat'] = latLngBounds.getSouth();
+        params['boundary.rect.max_lon'] = latLngBounds.getEast();
+        params['boundary.rect.max_lat'] = latLngBounds.getNorth();
+        return params;
+      }
 
       return params;
     },

--- a/spec/index.html
+++ b/spec/index.html
@@ -28,6 +28,7 @@
   <!-- spec files -->
   <script type='text/javascript' src='suites/ControlSpec.js'></script>
   <script type='text/javascript' src='suites/OptionsSpec.js'></script>
+  <script type='text/javascript' src='suites/SearchOptionsSpec.js'></script>
   <script type='text/javascript' src='suites/InterfaceSpec.js'></script>
 
   <script>

--- a/spec/suites/SearchOptionsSpec.js
+++ b/spec/suites/SearchOptionsSpec.js
@@ -1,0 +1,97 @@
+describe('Search options', function () {
+  var map;
+  var el;
+  var params;
+
+  beforeEach('initialize map', function () {
+    el = document.createElement('div');
+    el.style.cssText = 'position: absolute; left: 0; top: 0; width: 100%; height: 100%;';
+    document.body.appendChild(el);
+    map = L.map(el);
+    params = {};
+  });
+
+  afterEach('destroy map', function () {
+    document.body.removeChild(el);
+  });
+
+  // Tests return value of getBoundingBoxParam()
+  describe('bounds', function () {
+    it('should not set boundary.rect parameters by default', function () {
+      var geocoder = new L.Control.Geocoder();
+      geocoder.addTo(map);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lat']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lon']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lat']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lon']).to.be(undefined);
+    });
+
+    it('should not set boundary.rect parameters if bounds option is set to false', function () {
+      var geocoder = new L.Control.Geocoder('', {
+        bounds: false
+      });
+      geocoder.addTo(map);
+      expect(geocoder.options.bounds).to.be(false);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lat']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lon']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lat']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lon']).to.be(undefined);
+    });
+
+    it('should set boundary.rect to current map viewport if bounds option is set to true', function () {
+      var geocoder = new L.Control.Geocoder('', {
+        bounds: true
+      });
+      // Set map zoom and center to an arbitrary amount
+      map.setView([30, 30], 10);
+      geocoder.addTo(map);
+      expect(geocoder.options.bounds).to.be(true);
+      // Actual bounds depends on the viewport, just test to see that a number is returned
+      // and that they are properly ordered
+      var minLat = geocoder.getBoundingBoxParam(params)['boundary.rect.min_lat'];
+      var minLon = geocoder.getBoundingBoxParam(params)['boundary.rect.min_lon'];
+      var maxLat = geocoder.getBoundingBoxParam(params)['boundary.rect.max_lat'];
+      var maxLon = geocoder.getBoundingBoxParam(params)['boundary.rect.max_lon'];
+      expect(minLat).to.be.a('number');
+      expect(maxLat).to.be.a('number');
+      expect(minLat).to.be.lessThan(maxLat);
+      expect(minLon).to.be.a('number');
+      expect(maxLon).to.be.a('number');
+      expect(minLon).to.be.lessThan(maxLon);
+    });
+
+    it('should set boundary.rect from an L.Bounds object if provided', function () {
+      var geocoder = new L.Control.Geocoder('', {
+        bounds: new L.LatLngBounds([[10, 10], [40, 60]])
+      });
+      geocoder.addTo(map);
+      expect(geocoder.options.bounds.isValid()).to.be(true);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lat']).to.be(10);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lon']).to.be(10);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lat']).to.be(40);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lon']).to.be(60);
+    });
+
+    it('should set boundary.rect from a simple array format if provided', function () {
+      var geocoder = new L.Control.Geocoder('', {
+        bounds: [[10, 10], [40, 60]]
+      });
+      geocoder.addTo(map);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lat']).to.be(10);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lon']).to.be(10);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lat']).to.be(40);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lon']).to.be(60);
+    });
+
+    it('should not set boundary.rect if the bounds option is in an improper format', function () {
+      var geocoder = new L.Control.Geocoder('', {
+        bounds: [30, 40, 50, 60]
+      });
+      geocoder.addTo(map);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lat']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.min_lon']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lat']).to.be(undefined);
+      expect(geocoder.getBoundingBoxParam(params)['boundary.rect.max_lon']).to.be(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Leaflet allows [a shorthand array format](http://leafletjs.com/reference.html#latlngbounds) for boundaries:

> All Leaflet methods that accept LatLngBounds objects also accept them in a simple Array form (unless noted otherwise), so the bounds example above can be passed like this:
> 
> ```
> map.fitBounds([
>    [40.712, -74.227],
>    [40.774, -74.125]
> ]);
> ```

Attempting to pass this array format as a `bounds` option to the geocoder will throw an error. As a result, the function for setting boundary parameters has been rewritten to take this into account.

Also, test coverage for this is provided. 
