### PR TITLE
Add OSM attribution to example map

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -21,7 +21,7 @@
     // Create a basic Leaflet map
     var map = L.map('map').setView([40.7259, -73.9805], 12);
     L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+      attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     }).addTo(map);
 
     // Add Pelias geocoding plugin

--- a/examples/index.html
+++ b/examples/index.html
@@ -20,7 +20,9 @@
   <script>
     // Create a basic Leaflet map
     var map = L.map('map').setView([40.7259, -73.9805], 12);
-    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png').addTo(map);
+    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="www.openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    }).addTo(map);
 
     // Add Pelias geocoding plugin
     var options = {


### PR DESCRIPTION
This example uses the OSM tiles, so it should have an attribution for OSM on it. With tiles, the preferred is copyright OpenStreetMap contributors with a link to the copyright page.

This makes it appear like this:

![image](https://github-cloud.s3.amazonaws.com/assets%2F4380498%2F10956588%2F9ba3e316-8311-11e5-8ca4-386ff7aa82a0.png)
