### PR TITLE
Adding Accept Header so that json is preferred

### DIFF
--- a/dist/leaflet-geocoder-mapzen.js
+++ b/dist/leaflet-geocoder-mapzen.js
@@ -924,6 +924,9 @@
       var httpRequest = this.http_request(callback, context);
 
       httpRequest.open('GET', url + '?' + paramString);
+      if (httpRequest.constructor.name === 'XMLHttpRequest') {
+        httpRequest.setRequestHeader('Accept', 'application/json');
+      }
 
       setTimeout(function () {
         httpRequest.send(null);


### PR DESCRIPTION
This is useful when using a different URL other than the official, and the endpoints are able to return not only json, but xml or html for instance. Firefox sets this by default `Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"` so the plugin fails.
