### PR TITLE
Added specific width to leaflet-pelias-search-icon fix border glitch

### DIFF
--- a/dist/leaflet-geocoder-mapzen.css
+++ b/dist/leaflet-geocoder-mapzen.css
@@ -167,6 +167,7 @@ only screen and (min-device-pixel-ratio: 2) {
 .leaflet-pelias-search-icon {
   position: absolute;
   height: 100%;
+  width: 23px;
   background-image: url('images/search.png');
   background-repeat: no-repeat;
   background-position: center center;
@@ -180,6 +181,7 @@ only screen and (min-device-pixel-ratio: 2) {
   border-radius: 4px;
   border-bottom: 0;
   height: 100%;
+  width: 23px;
 }
 
 /* When expanded, search icon doesn't need right-side radii */


### PR DESCRIPTION
I added this plug-in to my project, and ran into an issue with the right border disappearing.

![screen shot 2016-02-25 at 11 35 46 am](https://cloud.githubusercontent.com/assets/8128188/13326945/dc379902-dbb5-11e5-900e-2f113cdc5c46.png)

Adding a specific width to leaflet-pelias-search-icon doesn't affect the original design, and prevents it from spilling over the right side if there is custom styling.
