### PR TITLE
Remove client-side filtering of autocomplete requests by layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.2 (April 18, 2016)
+
+- Mapzen Search API supports the `layers` parameter natively for autocomplete queries now! For more information, see this issue: https://github.com/pelias/api/issues/449. We removed all the code from this plugin that did the filtering on the client side, which was no longer needed.
+
 ## v1.5.1 (February 25, 2016)
 
 - Fix a bug where the results box is displayed when there is nothing in it. The effect was only noticeable when the results box is styled in a way that gives it dimension (e.g. a border or a minimum height).

--- a/dist/leaflet-geocoder-mapzen.js
+++ b/dist/leaflet-geocoder-mapzen.js
@@ -296,12 +296,6 @@
             }
           }
 
-          // Filter the unfiltered requests from the autocompletor
-          // This modifies the original response
-          if (type === 'autocomplete' && params.layers) {
-            results.features = this.filterFeaturesByLayers(results.features, params.layers);
-          }
-
           // Placeholder: handle place response
           if (type === 'place') {
             this.handlePlaceResponse(results);
@@ -321,62 +315,6 @@
           });
         }
       }, this);
-    },
-
-    /**
-     * Filters a Pelias response (likely from autocomplete)
-     * with the layer parameter given to it
-     * @param features - a FeatureCollection
-     * @param layers - string or array of layers queried
-     */
-    filterFeaturesByLayers: function (features, layers) {
-      var newFeatures = [];
-      // The 'coarse' alias is defined as these layers by the Pelias service.
-      // See documentation: https://mapzen.com/documentation/search/search/#filter-by-data-type
-      var coarseLayers = ['country', 'region', 'county', 'locality', 'localadmin', 'neighbourhood'];
-
-      // If layers parameter is an array, make a copy of it so that
-      // it does not modify the original options object.
-      if (L.Util.isArray(layers)) {
-        layers = layers.slice();
-      }
-
-      // The 'coarse' alias will be expanded to its defined layers.
-      // Handle if layers parameter is a string
-      if (layers === 'coarse') {
-        layers = coarseLayers;
-      } else if (L.Util.isArray(layers)) {
-        // And, handle if 'coarse' is in an array of layers
-        for (var i = 0; i < layers.length; i++) {
-          if (layers[i] === 'coarse') {
-            // Uses Array.splice() in an exotic way to splice one array into another array.
-            var args = [i, 1].concat(coarseLayers);
-            Array.prototype.splice.apply(layers, args);
-            // We will only do this once. If the layers provided is an array
-            // containing more than one instance of 'coarse', do not handle it.
-            // The filtering process below will ignore extra 'coarse' values, since
-            // no results will ever contain 'coarse' as a layer value.
-            break;
-          }
-        }
-      }
-
-      // Filtering the original features is done here.
-      for (var j = 0; j < features.length; j++) {
-        var feature = features[j];
-        if (feature.properties.layer === layers) {
-          newFeatures.push(feature);
-        } else if (L.Util.isArray(layers)) {
-          for (var k = 0; k < layers.length; k++) {
-            if (feature.properties.layer === layers[k]) {
-              newFeatures.push(feature);
-              break;
-            }
-          }
-        }
-      }
-
-      return newFeatures;
     },
 
     highlight: function (text, focus) {

--- a/spec/suites/ResultsSpec.js
+++ b/spec/suites/ResultsSpec.js
@@ -157,44 +157,5 @@ describe('Results', function () {
     });
   });
 
-  describe('#filterFeaturesByLayers', function () {
-    it('filters results by a layer', function () {
-      var filtered = geocoder.filterFeaturesByLayers(results.features, 'county');
-      expect(filtered[0].properties.layer).to.be('county');
-      expect(filtered[filtered.length - 1].properties.layer).to.be('county');
-    });
-
-    it('filters results by the layer "coarse"', function () {
-      var filtered = geocoder.filterFeaturesByLayers(results.features, 'coarse');
-      for (var i = 0; i < filtered.length; i++) {
-        expect(filtered[i].properties.layer).to.not.be('address');
-        expect(filtered[i].properties.layer).to.not.be('venue');
-      }
-    });
-
-    it('filters results by an array of layers', function () {
-      var filtered = geocoder.filterFeaturesByLayers(results.features, ['county', 'locality', 'neighbourhood']);
-      // How do you do a test for value A OR value B or value C?
-      // I'm just going to do this thing where if it fits, increment a counter, and expect
-      // it to match the length of the result.
-      var counter = 0;
-      for (var i = 0; i < filtered.length; i++) {
-        var layer = filtered[i].properties.layer;
-        if (layer === 'county' || layer === 'locality' || layer === 'neighbourhood') {
-          counter++;
-        }
-      }
-      expect(counter).to.be(filtered.length);
-    });
-
-    it('filters results by an array of layers that contains "coarse" as a value', function () {
-      var filtered = geocoder.filterFeaturesByLayers(results.features, ['neighbourhood', 'coarse']);
-      for (var i = 0; i < filtered.length; i++) {
-        expect(filtered[i].properties.layer).to.not.be('address');
-        expect(filtered[i].properties.layer).to.not.be('venue');
-      }
-    });
-  });
-
   it('throws away stale results');
 });


### PR DESCRIPTION
Mapzen Search API supports the `layers` parameter natively for autocomplete queries now! See this discussion. https://github.com/pelias/api/issues/449.

Previously I added some code to do some filtering of the results on the client-side, but now that the API sends only the layers requested for `/autocomplete`, the client side filtering code is no longer necessary (or helpful). So I've removed it.

Although this removes "functionality," it is because the Search API already provides it, so no difference in behavior should be observable and this is a minor version bump.
