### PR TITLE
Support boundary.country property on options

### DIFF
--- a/dist/leaflet-geocoder-mapzen.js
+++ b/dist/leaflet-geocoder-mapzen.js
@@ -44,6 +44,7 @@
       bounds: false,
       latlng: null,
       layers: null,
+      country: null, // sets param boundary.country (ie 'FRA' or 'GBR')
       panToPoint: true,
       pointIcon: true, // 'images/point_icon.png',
       polygonIcon: true, // 'images/polygon_icon.png',
@@ -75,6 +76,17 @@
       L.Util.setOptions(this, options);
       this.marker;
       this.markers = [];
+    },
+
+    getCountryCode: function (params) {
+      var country = this.options.country; // 'FRA'
+
+      if (!country) {
+        return params;
+      }
+
+      params['boundary.country'] = country;
+      return params;
     },
 
     getLayers: function (params) {
@@ -212,6 +224,7 @@
       params = this.getBoundingBoxParam(params);
       params = this.getLatlngParam(params);
       params = this.getLayers(params);
+      params = this.getCountryCode(params);
 
       // Search API key
       if (this.apiKey) {


### PR DESCRIPTION
I needed to restrict results to country FRANCE. I know the feature is only available in service url `/search` not in `/autocomplete` but could not find how to pass this param in my options when creating the geocoder instance so I did this little hack. Let me know if it can be written better (sorry for my english !) 
Thanks.

``` javascript
var my_geocoder = L.control.geocoder(mapzen_key, {
    country: 'FRA', // sets param boundary.country (ie 'FRA' or 'GBR', etc)
    autocomplete:false // to use /search service instead of /autocomplete (though it whould be cool to have it work with autocomplete !
}).addTo(map);
```
