### PR TITLE
Rename the latlng option to focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.6.0 (Future)
+
+- The geocoder now has a `.version` property. Sometimes you just need to know.
+- The `latlng` option has been renamed to `focus` to be closer to the syntax for [Mapzen Search](https://mapzen.com/documentation/search/search/). Also, the behavior has changed to automatically prioritize results closer to the current view by default. You can turn this off by explicitly setting `focus: false`. The `latlng` property will still work but we will display a deprecation warning and remove it in the next major version.
+
 ## v1.5.2 (April 18, 2016)
 
 - Mapzen Search API supports the `layers` parameter natively for autocomplete queries now! For more information, see this issue: https://github.com/pelias/api/issues/449. We removed all the code from this plugin that did the filtering on the client side, which was no longer needed.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ option      | description                               | default value
 ----------- | ----------------------------------------- | ---------------------
 **url** | _String._ Host endpoint for a Pelias-compatible search API. | `'https://search.mapzen.com/v1'`
 **bounds** | _[Leaflet LatLngBounds object](http://leafletjs.com/reference.html#latlngbounds)_ or _Boolean_. If `true`, search is bounded by the current map view. You may also provide a custom bounding box in form of a LatLngBounds object. | `false`
-**latlng** | _[Leaflet LatLng object](http://leafletjs.com/reference.html#latlng)_ or _Boolean_. If `true`, search is biased to prioritize results near the center of the current view. You may also provide a custom LatLng value (in any of the [accepted Leaflet formats](http://leafletjs.com/reference.html#latlng)) to act as the center bias. | `false`
+**focus** | _[Leaflet LatLng object](http://leafletjs.com/reference.html#latlng)_ or _Boolean_. If `true`, search prioritizes results near the center of the current view. You may also provide a custom LatLng value (in any of the [accepted Leaflet formats](http://leafletjs.com/reference.html#latlng)) to act as the center bias. **This option was formerly called `latlng`.** | `true`
 **layers** | _String_ or _Array_. Filters results by layers ([documentation](https://mapzen.com/documentation/search/search/#filter-by-data-type)). If left blank, results will come from all available layers. | `null`
 
 ### Interaction behavior
@@ -134,13 +134,13 @@ L.control.geocoder('<your-api-key>', {
 
 // Searching nearby [50.5, 30.5]
 L.control.geocoder('<your-api-key>', {
-  latlng: [50.5, 30.5], // this can also written as {lat: 50.5, lon: 30.5} or L.latLng(50.5, 30.5)
+  focus: [50.5, 30.5], // this can also written as {lat: 50.5, lon: 30.5} or L.latLng(50.5, 30.5)
   placeholder: 'Search nearby [50.5, 30.5]'
 }).addTo(map);
 
 // Taking just the center of the map (lat/lon) into account
 L.control.geocoder('<your-api-key>', {
-  latlng: true,
+  focus: true,
   placeholder: 'Search nearby'
 }).addTo(map);
 

--- a/index.html
+++ b/index.html
@@ -86,8 +86,7 @@
       var geocoder = L.control.geocoder('search-MKZrG6M', {
         fullWidth: 650,
         expanded: true,
-        markers: true,
-        latlng: true
+        markers: true
       }).addTo(map);
 
       // Re-sort control order so that geocoder is on top

--- a/spec/suites/InterfaceSpec.js
+++ b/spec/suites/InterfaceSpec.js
@@ -26,15 +26,21 @@ describe('Interface', function () {
   });
 
   describe('The × button (reset)', function () {
-    it('should not be visible when control is first added', function () {
-      var geocoder = new L.Control.Geocoder();
+    var geocoder;
+
+    beforeEach('initialize geocoder', function () {
+      geocoder = new L.Control.Geocoder();
       geocoder.addTo(map);
+
+      // Prevent geocoder.callPelias() from getting called during these tests, so stub it
+      sinon.stub(geocoder, 'callPelias');
+    });
+
+    it('should not be visible when control is first added', function () {
       expect(geocoder._reset.classList.contains('leaflet-pelias-hidden')).to.be(true);
     });
 
     it('should be visible when input has 1 character', function () {
-      var geocoder = new L.Control.Geocoder();
-      geocoder.addTo(map);
       // Simulates input action
       geocoder._input.focus();
       geocoder._input.value = 'a';
@@ -43,8 +49,6 @@ describe('Interface', function () {
     });
 
     it('should be visible when input has 2 characters', function () {
-      var geocoder = new L.Control.Geocoder();
-      geocoder.addTo(map);
       // Simulates input action
       geocoder._input.focus();
       geocoder._input.value = 'bb';
@@ -53,9 +57,6 @@ describe('Interface', function () {
     });
 
     it('should reset input when clicked', function () {
-      var geocoder = new L.Control.Geocoder();
-      geocoder.addTo(map);
-
       // Simulates input action
       geocoder._input.focus();
       geocoder._input.value = 'sometext';
@@ -69,10 +70,7 @@ describe('Interface', function () {
     });
 
     it('fires `reset` event', function () {
-      var geocoder = new L.Control.Geocoder();
       var onReset = sinon.spy();
-
-      geocoder.addTo(map);
       geocoder.on('reset', onReset);
 
       happen.click(geocoder._reset);

--- a/spec/suites/SearchOptionsSpec.js
+++ b/spec/suites/SearchOptionsSpec.js
@@ -144,28 +144,35 @@ describe('Search options', function () {
     });
   });
 
-  // Tests return value of getLatLngParam()
-  describe('latlng', function () {
-    it('should not set focus.point parameters by default', function () {
+  // Tests return value of getFocusParam()
+  describe('focus', function () {
+    it('should set focus.point parameters by default', function () {
       var geocoder = new L.Control.Geocoder();
 
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(undefined);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(undefined);
+      // Set map zoom and center to an arbitrary amount
+      var map = createMap();
+      map.setView([30, 30], 10);
+      geocoder.addTo(map);
+
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(30);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(30);
+
+      destroyMap(map);
     });
 
     it('should not set focus.point parameters if option is set to false', function () {
       var geocoder = new L.Control.Geocoder('', {
-        latlng: false
+        focus: false
       });
 
-      expect(geocoder.options.latlng).to.be(false);
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(undefined);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(undefined);
+      expect(geocoder.options.focus).to.be(false);
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(undefined);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(undefined);
     });
 
     it('should set focus.point to current map center if option is set to true', function () {
       var geocoder = new L.Control.Geocoder('', {
-        latlng: true
+        focus: true
       });
 
       // Set map zoom and center to an arbitrary amount
@@ -174,49 +181,49 @@ describe('Search options', function () {
       geocoder.addTo(map);
 
       // Make sure option is set to the correct boolean
-      expect(geocoder.options.latlng).to.be(true);
+      expect(geocoder.options.focus).to.be(true);
 
       // Make sure the params match the map center we set it to
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(30);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(30);
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(30);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(30);
 
       destroyMap(map);
     });
 
     it('should set focus.point from an array [lat, lng] if provided', function () {
       var geocoder = new L.Control.Geocoder('', {
-        latlng: [50, 30]
+        focus: [50, 30]
       });
 
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(50);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(30);
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(50);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(30);
     });
 
     it('should set focus.point from an object {lon, lat} if provided', function () {
       var geocoder = new L.Control.Geocoder('', {
-        latlng: {lon: 30, lat: 50}
+        focus: {lon: 30, lat: 50}
       });
 
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(50);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(30);
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(50);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(30);
     });
 
     it('should set focus.point from an object {lat, lng} if provided', function () {
       var geocoder = new L.Control.Geocoder('', {
-        latlng: {lat: 50, lng: 30}
+        focus: {lat: 50, lng: 30}
       });
 
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(50);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(30);
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(50);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(30);
     });
 
     it('should set focus.point from an L.LatLng object if provided', function () {
       var geocoder = new L.Control.Geocoder('', {
-        latlng: L.latLng(50.5, 30.5)
+        focus: L.latLng(50.5, 30.5)
       });
 
-      expect(geocoder.getLatlngParam(params)['focus.point.lat']).to.be(50.5);
-      expect(geocoder.getLatlngParam(params)['focus.point.lon']).to.be(30.5);
+      expect(geocoder.getFocusParam(params)['focus.point.lat']).to.be(50.5);
+      expect(geocoder.getFocusParam(params)['focus.point.lon']).to.be(30.5);
     });
   });
 


### PR DESCRIPTION
This is to bring this option's terminology closer in line with the Mapzen Search API, where `focus` is a concept that did not translate particularly well to the geocoder when the option was called `latlng`. The `latlng` option will still work for now, but it will display a deprecation warning for users if they continue to use it.

Also, `focus` is set to `true` by default, which means autocomplete results should always be a little more relevant to the current view (unless explicitly disabled). This may supercede #65.
