### PR TITLE
Support arbitrary params through a params option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - The geocoder now has a `.version` property. Sometimes you just need to know.
 - The `latlng` option has been renamed to `focus` to be closer to the syntax for [Mapzen Search](https://mapzen.com/documentation/search/search/). Also, the behavior has changed to automatically prioritize results closer to the current view by default. You can turn this off by explicitly setting `focus: false`. The `latlng` property will still work but we will display a deprecation warning and remove it in the next major version.
+- Mapzen Search API accepts many query parameters (such as for filtering, bounding results, and so on) that don't have a corresponding convenience option in this plugin. Rather than support each option individually, we now provide a **params** option which allows developers to pass through any parameter they wish to the API. Valid parameters will be anything that is covered in the [Mapzen Search documentation](https://mapzen.com/documentation/search/) (so please read it carefully), but the plugin will not throw away invalid parameters in case new parameters are supported in the future.
 
 ## v1.5.2 (April 18, 2016)
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ option      | description                               | default value
 **focus** | _[Leaflet LatLng object](http://leafletjs.com/reference.html#latlng)_ or _Boolean_. If `true`, search prioritizes results near the center of the current view. You may also provide a custom LatLng value (in any of the [accepted Leaflet formats](http://leafletjs.com/reference.html#latlng)) to act as the center bias. | `true`
 **latlng** | _Deprecated._ Please use **focus** instead. |
 **layers** | _String_ or _Array_. Filters results by layers ([documentation](https://mapzen.com/documentation/search/search/#filter-by-data-type)). If left blank, results will come from all available layers. | `null`
+**params** | _Object_. An object of key-value pairs which will be serialized into query parameters that will be passed to the API. For a full list of supported parameters, please read the [Mapzen Search documentation](https://mapzen.com/documentation/search/). This allows custom queries that are not already supported by the convenience options listed above. Note that in case of conflicting parameters, this option takes precedence. All supplied parameters are passed through; this library doesn't know which are valid parameters and which are not. | `null`
 
 ### Interaction behavior
 

--- a/dist/leaflet-geocoder-mapzen.js
+++ b/dist/leaflet-geocoder-mapzen.js
@@ -178,6 +178,34 @@
       return params;
     },
 
+    // @method getParams(params: Object)
+    // Collects all the parameters in a single object from various options
+    getParams: function (params) {
+      params = params || {};
+      params = this.getBoundingBoxParam(params);
+      params = this.getFocusParam(params);
+      params = this.getLayers(params);
+
+      // Search API key
+      if (this.apiKey) {
+        params.api_key = this.apiKey;
+      }
+
+      var newParams = this.options.params;
+
+      if (!newParams) {
+        return params;
+      }
+
+      if (typeof newParams === 'object') {
+        for (var prop in newParams) {
+          params[prop] = newParams[prop];
+        }
+      }
+
+      return params;
+    },
+
     search: function (input) {
       // Prevent lack of input from sending a malformed query to Pelias
       if (!input) return;
@@ -223,14 +251,7 @@
     maxReqTimestampRendered: new Date().getTime(),
 
     callPelias: function (endpoint, params, type) {
-      params = this.getBoundingBoxParam(params);
-      params = this.getFocusParam(params);
-      params = this.getLayers(params);
-
-      // Search API key
-      if (this.apiKey) {
-        params.api_key = this.apiKey;
-      }
+      params = this.getParams(params);
 
       L.DomUtil.addClass(this._search, 'leaflet-pelias-loading');
 

--- a/spec/suites/SearchOptionsSpec.js
+++ b/spec/suites/SearchOptionsSpec.js
@@ -260,4 +260,99 @@ describe('Search options', function () {
       expect(geocoder.getLayers(params)['layers']).to.eql(['venue', 'address']);
     });
   });
+
+  // Pass-through query parameters
+  describe('query parameters', function () {
+    it('should return original parameters if option is not set', function () {
+      var geocoder = new L.Control.Geocoder({
+        layers: 'coarse', // Convenience option for parameter
+        focus: false      // This just prevents geocoder from looking for the map
+      });
+      var params = geocoder.getParams();
+      var testParams = {
+        layers: 'coarse'
+      };
+
+      expect(params).to.eql(testParams);
+    });
+
+    it('should return original parameters if option is a falsy value', function () {
+      // Test `params: false`
+      var geocoder1 = new L.Control.Geocoder({
+        layers: 'coarse', // Convenience option for parameter
+        focus: false,     // This prevents geocoder from requiring that Leaflet is initialized
+        params: false
+      });
+      var params1 = geocoder1.getParams();
+
+      // Test `params: null`
+      var geocoder2 = new L.Control.Geocoder({
+        layers: 'coarse', // Convenience option for parameter
+        focus: false,     // This prevents geocoder from requiring that Leaflet is initialized
+        params: null
+      });
+      var params2 = geocoder2.getParams();
+
+      var testParams = {
+        layers: 'coarse'
+      };
+
+      expect(params1).to.eql(testParams);
+      expect(params2).to.eql(testParams);
+    });
+
+    it('should return combined parameters if option is set', function () {
+      var geocoder = new L.Control.Geocoder({
+        layers: 'coarse', // Convenience option for parameter
+        focus: false,     // This prevents geocoder from requiring that Leaflet is initialized
+        params: {
+          'boundary.rect.min_lat': -10,
+          'boundary.country': 'AUS',
+          'sources': 'oa'
+        }
+      });
+      var params = geocoder.getParams();
+      var testParams = {
+        'layers': 'coarse',
+        'boundary.rect.min_lat': -10,
+        'boundary.country': 'AUS',
+        'sources': 'oa'
+      };
+
+      expect(params).to.eql(testParams);
+    });
+
+    it('should overwrite parameters set by convenience options', function () {
+      var geocoder = new L.Control.Geocoder({
+        layers: ['venue', 'address'], // Convenience option for parameter
+        focus: false,     // This prevents geocoder from requiring that Leaflet is initialized
+        params: {
+          layers: 'coarse'
+        }
+      });
+      var params = geocoder.getParams();
+      var testParams = {
+        'layers': 'coarse'
+      };
+
+      expect(params).to.eql(testParams);
+    });
+
+    it('should not remove unknown parameters', function () {
+      var geocoder = new L.Control.Geocoder({
+        layers: 'coarse', // Convenience option for parameter
+        focus: false,     // This prevents geocoder from requiring that Leaflet is initialized
+        params: {
+          unknownParam: false
+        }
+      });
+      var params = geocoder.getParams();
+      var testParams = {
+        'layers': 'coarse',
+        'unknownParam': false
+      };
+
+      expect(params).to.eql(testParams);
+    });
+  });
 });


### PR DESCRIPTION
See also #103, #121, #125.

Not being able to support all of Mapzen Search's API has been a long-standing problem for this plugin. We have been mostly blocked on designing the "proper" interface for this. After a short discussion with @orangejulius earlier today, we determined that the more we have "special" syntax in the geocoder, the more work it is for us to support and the more work it is for the developer to translate Mapzen Search API parameters to geocoder plugin options.

The solution might be this: expose a **`params`** option which accepts an object of key-value pairs that serializes to query parameters for the API. This does not remove any of the convenience options that already exist, but provides an interface which allows any developer already familiar with Mapzen Search API (or will read its documentation) to pass through all the desired parameters in a single object. It is future-proof: it does not throw away any parameters, so if Mapzen Search adds new query parameters, no special code is needed for the geocoder to support those parameters immediately.

Furthermore this resolves one of the blockers in transitioning Mapzen's demo map UI to "citysearch v2" -- the `params` object easily allows us to set `sources: 'wof'` to force filtering to Who's on First results. 
