### PR TITLE
added geocoder.resetInput() to "methods" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ geocoder.focus();
 // Removes focus from the geocoder input.
 // This also clears results and collapses the geocoder (if enabled).
 geocoder.blur();
+
+// Empties the geocoder input.
+// This also clears results, removes focus and collapses the geocoder (if enabled).
+geocoder.resetInput();
 ```
 
 ### Events


### PR DESCRIPTION
No other of the mentioned method actually resets the input.
