### PR TITLE
check if attributionControl is defined before calling it's property

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1048,7 +1048,9 @@ var Geocoder = L.Control.extend({
   },
 
   onRemove: function (map) {
-    map.attributionControl.removeAttribution(this.options.attribution);
+    if (map.attributionControl) {
+      map.attributionControl.removeAttribution(this.options.attribution);
+    }
   }
 });
 


### PR DESCRIPTION
Just doing the same for `removeAttribution` as it's done for `addAttribution` at line 1017.