### PR TITLE
Prevent overriding scrollWheelZoom when hovering over geocoder results.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1041,6 +1041,12 @@ var Geocoder = L.Control.extend({
 
   _disableMapScrollWheelZoom: function (event) {
     // Prevent scrolling over results list from zooming the map, if enabled
+    // Skip if it's already disabled. This prevents overriding the original
+    // map.scrollWheelZoom setting.
+    if (!this._map.scrollWheelZoom.enabled()) {
+        return;
+    }
+
     this._scrollWheelZoomEnabled = this._map.scrollWheelZoom.enabled();
     if (this._scrollWheelZoomEnabled) {
       this._map.scrollWheelZoom.disable();

--- a/src/core.js
+++ b/src/core.js
@@ -1044,7 +1044,7 @@ var Geocoder = L.Control.extend({
     // Skip if it's already disabled. This prevents overriding the original
     // map.scrollWheelZoom setting.
     if (!this._map.scrollWheelZoom.enabled()) {
-        return;
+      return;
     }
 
     this._scrollWheelZoomEnabled = this._map.scrollWheelZoom.enabled();


### PR DESCRIPTION
This happens when you start searching and the mouse cursor is hovering right over where the results should appear. `_disableMapScrollWheelZoom` gets called twice and then `this._scrollWheelZoomEnabled` is set to false regardless of the original setting. Checking to see if it is already disabled prevents this behavior.

http://recordit.co/aALzpm7tNh

This demonstrates the steps needed to reproduce. After doing this you can no longer zoom using the scroll wheel.