### PR TITLE
update for search url to geocode.earth

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Some options affect the Pelias query itself.
 
 option      | description                               | default value
 ----------- | ----------------------------------------- | ---------------------
-**url** | _String._ Host endpoint for a Pelias-compatible search API. | `'https://search.mapzen.com/v1'`
+**url** | _String._ Host endpoint for a Pelias-compatible search API. | `'https://api.geocode.earth/v1'`
 **bounds** | _[Leaflet LatLngBounds object](http://leafletjs.com/reference.html#latlngbounds)_ or _Boolean_. If `true`, search is bounded by the current map view. You may also provide a custom bounding box in form of a LatLngBounds object. _Note: `bounds` is not supported by autocomplete._ | `false`
 **focus** | _[Leaflet LatLng object](http://leafletjs.com/reference.html#latlng)_ or _Boolean_. If `true`, search and autocomplete prioritizes results near the center of the current view. You may also provide a custom LatLng value (in any of the [accepted Leaflet formats](http://leafletjs.com/reference.html#latlng)) to act as the center bias. | `true`
 **latlng** | _Deprecated._ Please use **focus** instead. |
@@ -199,7 +199,7 @@ These options affect the plugin's appearance and interaction behavior.
 option      | description                               | default value
 ----------- | ----------------------------------------- | ---------------------
 **position** | _String_. Corner in which to place the geocoder control. Values correspond to Leaflet [control positions](http://leafletjs.com/reference.html#control-positions). | `'topleft'`
-**attribution** | _String_. Attribution text that will be appended to Leaflet’s [attribution control](http://leafletjs.com/reference-1.0.3.html#control-attribution). Set to a blank string or `null` to disable adding the plugin’s default attribution. | `'Geocoding by <a href="https://mapzen.com/projects/search/">Mapzen</a>'`
+**attribution** | _String_. Attribution text that will be appended to Leaflet’s [attribution control](http://leafletjs.com/reference-1.0.3.html#control-attribution). Set to a blank string or `null` to disable adding the plugin’s default attribution. | `'Geocoding by <a href="https://geocode.earth">Geocode.earth</a>'`
 **textStrings** | _Object_. An object of string values that replace text strings in the geocoder control, so you can provide your own custom messages or localization. | See “Custom text strings” section below.
 **placeholder** | _String_. Placeholder text to display in the search input box. This is an alias for **`textStrings.INPUT_PLACEHOLDER`**. Set to a blank string or `null` to disable. | `'Search'`
 **title** | _Deprecated._ Please use **`textStrings.INPUT_TITLE_ATTRIBUTE** instead. |

--- a/src/core.js
+++ b/src/core.js
@@ -55,8 +55,8 @@ var Geocoder = L.Control.extend({
 
   options: {
     position: 'topleft',
-    attribution: 'Geocoding by <a href="https://mapzen.com/projects/search/">Mapzen</a>',
-    url: 'https://search.mapzen.com/v1',
+    attribution: 'Geocoding by <a href="https://geocode.earth">Geocode.earth</a>',
+    url: 'https://api.geocode.earth/v1',
     placeholder: null, // Note: this is now just an alias for textStrings.INPUT_PLACEHOLDER
     bounds: false,
     focus: true,
@@ -79,7 +79,7 @@ var Geocoder = L.Control.extend({
     // version, because XDomainRequest does not allow http-to-https requests
     // This is set first so it can always be overridden by the user
     if (window.XDomainRequest) {
-      this.options.url = '//search.mapzen.com/v1';
+      this.options.url = '//api.geocode.earth/v1';
     }
 
     // If the apiKey is omitted entirely and the


### PR DESCRIPTION

Hi, 

I didn't see a build process in contributing.md and since this is a relatively (on the surface) update, I just updated my in my dist file and confirmed that my changes work for those with a geocode.earth account using the leaflet-geocoder. 

I realize that there's likely a whole lot more that needs to be done before this would likely get approved (just from what I could see: remove the rest of the mapzen branding; go to nextzen tiles, update all of the examples, etc) but I needed to update a personal project from mapzen to geocode.earth and figured I'd share this with anyone else who'd need it and to help get the ball rolling :) 
