### PR TITLE
De-mapzenify round 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![npm version](https://img.shields.io/npm/v/pelias-leaflet-plugin.svg?style=flat-square)](https://www.npmjs.com/package/pelias-leaflet-plugin)
-[![CircleCI](https://img.shields.io/circleci/project/mapzen/leaflet-geocoder.svg?style=flat-square)](https://circleci.com/gh/mapzen/leaflet-geocoder/)
-[![David devDependencies](https://img.shields.io/david/dev/mapzen/leaflet-geocoder.svg?style=flat-square)](https://david-dm.org/mapzen/leaflet-geocoder/#info=devDependencies)
-[![Coverage Status](https://img.shields.io/coveralls/mapzen/leaflet-geocoder.svg?style=flat-square)](https://coveralls.io/github/mapzen/leaflet-geocoder?branch=master)
+[![Build Status](https://travis-ci.com/pelias/leaflet-geocoder.svg?branch=master)](https://travis-ci.com/pelias/leaflet-geocoder)
 [![Gitter chat](https://img.shields.io/gitter/room/pelias/pelias.svg?style=flat-square)](https://gitter.im/pelias/pelias)
 [![Leaflet 1.0.0 ready](https://img.shields.io/badge/Leaflet%201.0.0-%E2%9C%93-brightgreen.svg?style=flat-square)](http://leafletjs.com/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://img.shields.io/npm/v/leaflet-geocoder-mapzen.svg?style=flat-square)](https://www.npmjs.com/package/leaflet-geocoder-mapzen)
+[![npm version](https://img.shields.io/npm/v/pelias-leaflet-plugin.svg?style=flat-square)](https://www.npmjs.com/package/pelias-leaflet-plugin)
 [![CircleCI](https://img.shields.io/circleci/project/mapzen/leaflet-geocoder.svg?style=flat-square)](https://circleci.com/gh/mapzen/leaflet-geocoder/)
 [![David devDependencies](https://img.shields.io/david/dev/mapzen/leaflet-geocoder.svg?style=flat-square)](https://david-dm.org/mapzen/leaflet-geocoder/#info=devDependencies)
 [![Coverage Status](https://img.shields.io/coveralls/mapzen/leaflet-geocoder.svg?style=flat-square)](https://coveralls.io/github/mapzen/leaflet-geocoder?branch=master)
@@ -350,10 +350,10 @@ geocoder.removeFrom(map); // or geocoder.remove() in Leaflet v1
 If you `require()` or `import` and set it to a variable, you can also use `new` with that variable.
 
 ```javascript
-var MyGeocoderPlugin = require('leaflet-geocoder-mapzen');
+var MyGeocoderPlugin = require('pelias-leaflet-plugin');
 
 // Alternatively
-import MyGeocoderPlugin from 'leaflet-geocoder-mapzen';
+import MyGeocoderPlugin from 'pelias-leaflet-plugin';
 
 // Then
 var geocoder = new MyGeocoderPlugin('<your-api-key>');

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "leaflet-geocoder-mapzen",
+  "name": "pelias-leaflet-plugin",
   "version": "1.9.4",
-  "homepage": "https://github.com/mapzen/leaflet-geocoder",
+  "homepage": "https://github.com/pelias/leaflet-plugin",
   "authors": [
     "Harish Krishna",
     "Lou Huang <lou@mapzen.com>"


### PR DESCRIPTION
This round updates the NPM package name everywhere.

Unfortunately the new package is not yet on cdnjs, so much of the documentation will still have to point to the older version.